### PR TITLE
Update copyright notice in MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Saul Shanabrook
+Copyright (c) 2020 Consortium for Python Data API Standards contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We don't do copyright assignment in this organization, so the author
of each line of content (or possibly their employer, depending on contracts)
is the copyright holder; that's normally not reflected in the license
text itself though, that's in the commit history.

I considered two copyright lines, but opted for the same license on
all repos in this org, and also because two lines tends to confuse
license checkers like the one GitHub runs (licensee).