### PR TITLE
Fix typo in COMPARE_OP processing

### DIFF
--- a/record_api/core.py
+++ b/record_api/core.py
@@ -436,7 +436,7 @@ class Stack:
         val = self.opvalcompare
         COMPARISONS = {
             "<": op.lt,
-            "<": op.le,
+            "<=": op.le,
             "==": op.eq,
             "!=": op.ne,
             ">": op.gt,


### PR DESCRIPTION
"less or equal to" was missing from the COMPARE_OP processing function, its probably a typo.