### PR TITLE
Empty fields

### DIFF
--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -30,21 +30,6 @@ def bad_name(name: str) -> bool:
     return not name.isidentifier()
 
 
-class BaseModel(pydantic.BaseModel):
-    def __repr_args__(self) -> pydantic.ReprArgs:  # type: ignore
-        for k, v in super().__repr_args__():
-            if v:
-                yield k, v
-
-    def validate_again(self) -> None:
-        """
-        Use to manually validate for debugging when fields change
-        """
-        _, _, validation_error = pydantic.validate_model(type(self), self.dict())
-        if validation_error:
-            raise validation_error
-
-
 class API(BaseModel):
     # Dotted module name to module
     modules: typing.Dict[str, Module] = pydantic.Field(default_factory=dict)
@@ -58,7 +43,7 @@ class API(BaseModel):
         return self
 
     def json(self, **kwargs) -> str:
-        return super().json(exclude_none=True, **kwargs)
+        return super().json(exclude_none=True, skip_defaults=True, **kwargs)
 
 
 class Module(BaseModel):

--- a/record_api/type_analysis.py
+++ b/record_api/type_analysis.py
@@ -133,8 +133,8 @@ class BaseModel(pydantic.BaseModel):
         return hash((type(self),) + tuple(self.__dict__.values()))
 
     # Set fields set to be all those that are truthy, so only those are expoed with `skip_defaults`
-    @property
-    def __fields_set__(self) -> typing.Set[str]:
+    @property  # type: ignore
+    def __fields_set__(self) -> typing.Set[str]: # type: ignore
         s = set()
         for k, v in self.__values__.items():
             if v:

--- a/record_api/type_analysis.py
+++ b/record_api/type_analysis.py
@@ -38,7 +38,6 @@ __all__ = [
     "MethodDescriptorOutput",
     "parser_config",
     "NumpyUfuncOutput",
-    "BaseModel",
 ]
 
 # If there are more than this amount in a union, just use any
@@ -131,33 +130,6 @@ class BaseModel(pydantic.BaseModel):
     # https://github.com/samuelcolvin/pydantic/issues/1303#issuecomment-599712964
     def __hash__(self):
         return hash((type(self),) + tuple(self.__dict__.values()))
-
-    # Set fields set to be all those that are truthy, so only those are expoed with `skip_defaults`
-    @property  # type: ignore
-    def __fields_set__(self) -> typing.Set[str]: # type: ignore
-        s = set()
-        for k, v in self.__values__.items():
-            if v:
-                s.add(k)
-        return s
-
-    @__fields_set__.setter
-    def __fields_set__(self, val: typing.Set[str]) -> None:
-        pass
-
-    def __repr_args__(self) -> pydantic.ReprArgs:  # type: ignore
-        # Dont show empty valyes
-        for k, v in super().__repr_args__():
-            if v:
-                yield k, v
-
-    def validate_again(self) -> None:
-        """
-        Use to manually validate for debugging when fields change
-        """
-        _, _, validation_error = pydantic.validate_model(type(self), self.dict())
-        if validation_error:
-            raise validation_error
 
 
 class OutputTypeBase(BaseModel, abc.ABC):


### PR DESCRIPTION
Fixes https://github.com/data-apis/python-record-api/issues/53 by skipping serializing any empty fields, to reduce the size of the JSON documents.