### PR TITLE
Fix ordering dictionary bug

### DIFF
--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -710,7 +710,7 @@ def possibly_order_dict(
     """
     Resort dict by topographical sorting of order
     """
-    return {k: d[k] for k in networkx.topological_sort(networkx.DiGraph(order))}
+    return {k: d[k] for k in networkx.topological_sort(networkx.DiGraph(order))} or d
 
 
 def unify_named_types(


### PR DESCRIPTION
When we only have one item in a dict, there are no ordering edges,
but we should still emit the one node.

Fixes #52