### PR TITLE
Record function returned types

### DIFF
--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -374,6 +374,9 @@ class Signature(BaseModel):
     var_kw: typing.Optional[typing.Tuple[str, Type]] = None
 
     metadata: typing.Dict[str, int] = pydantic.Field(default_factory=dict)
+    return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = pydantic.Field(
+        default_factory=type(None)
+    )
 
     @pydantic.validator("pos_only_required")
     @classmethod
@@ -408,6 +411,14 @@ class Signature(BaseModel):
             raise ValueError(repr(all_keys))
         return values
 
+    @property
+    def return_type_annotation(self) -> typing.Optional[cst.Annotation]:
+        return_type_annotation = None
+        if self.return_type:
+            return_type = create_type(self.return_type)
+            return_type_annotation = cst.Annotation(return_type.annotation)
+        return return_type_annotation
+
     def function_def(
         self,
         name: str,
@@ -427,6 +438,7 @@ class Signature(BaseModel):
                 [cst.SimpleStatementLine([s]) for s in self.body(indent)]
             ),
             decorators,
+            self.return_type_annotation
         )
 
     def body(self, indent: int) -> typing.Iterable[cst.BaseSmallStatement]:
@@ -508,13 +520,17 @@ class Signature(BaseModel):
 
     @classmethod
     def from_params(
-        cls, args: typing.List[object] = [], kwargs: typing.Dict[str, object] = {}
+        cls,
+        args: typing.List[object] = [],
+        kwargs: typing.Dict[str, object] = {},
+        return_type: typing.Optional[Type] = type(None),
     ) -> Signature:
         # If we don't know what the args/kwargs are, assume the args are positional only
         # and the kwargs and keyword only
         return cls(
             pos_only_required={f"_{i}": create_type(v) for i, v in enumerate(args)},
             kw_only_required={k: create_type(v) for k, v in kwargs.items()},
+            return_type=return_type
         )
 
     @classmethod
@@ -525,6 +541,7 @@ class Signature(BaseModel):
         var_pos: typing.Optional[typing.Tuple[str, typing.List[object]]] = None,
         kw_only: typing.Dict[str, object] = {},
         var_kw: typing.Optional[typing.Tuple[str, typing.Dict[str, object]]] = None,
+        return_type: typing.Optional[Type] = None,
     ) -> Signature:
         return cls(
             pos_only_required={k: create_type(v) for k, v in pos_only},
@@ -538,6 +555,7 @@ class Signature(BaseModel):
                 if var_kw
                 else None
             ),
+            return_type=return_type
         )
 
     def content_equal(self, other: Signature) -> bool:

--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -375,7 +375,7 @@ class Signature(BaseModel):
 
     metadata: typing.Dict[str, int] = pydantic.Field(default_factory=dict)
     return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = pydantic.Field(
-        default_factory=type(None)
+        default_factory=dict
     )
 
     @pydantic.validator("pos_only_required")

--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -374,7 +374,7 @@ class Signature(BaseModel):
     var_kw: typing.Optional[typing.Tuple[str, Type]] = None
 
     metadata: typing.Dict[str, int] = pydantic.Field(default_factory=dict)
-    return_type: OutputType = pydantic.Field()
+    return_type: OutputType = None
 
     @pydantic.validator("pos_only_required")
     @classmethod
@@ -572,6 +572,7 @@ class Signature(BaseModel):
         self._copy_var_pos(other)
         self._copy_kw_only(other)
         self._copy_var_kw(other)
+        self._copy_return_type(other)
 
         update_add(self.metadata, other.metadata)
         self._trim_positional_only_args()
@@ -731,6 +732,13 @@ class Signature(BaseModel):
             unify_named_types((self.var_kw, other.var_kw,))
             if self.var_kw and other.var_kw
             else (self.var_kw or other.var_kw)
+        )
+
+    def _copy_return_type(self, other: Signature) -> None:
+        self.return_type = (
+            unify((self.return_type, other.return_type,))
+            if self.return_type and other.return_type
+            else (self.return_type or other.return_type)
         )
 
 

--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -523,7 +523,7 @@ class Signature(BaseModel):
         cls,
         args: typing.List[object] = [],
         kwargs: typing.Dict[str, object] = {},
-        return_type: typing.Optional[Type] = type(None),
+        return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = {},
     ) -> Signature:
         # If we don't know what the args/kwargs are, assume the args are positional only
         # and the kwargs and keyword only
@@ -541,7 +541,7 @@ class Signature(BaseModel):
         var_pos: typing.Optional[typing.Tuple[str, typing.List[object]]] = None,
         kw_only: typing.Dict[str, object] = {},
         var_kw: typing.Optional[typing.Tuple[str, typing.Dict[str, object]]] = None,
-        return_type: typing.Optional[Type] = None,
+        return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = {},
     ) -> Signature:
         return cls(
             pos_only_required={k: create_type(v) for k, v in pos_only},

--- a/record_api/apis.py
+++ b/record_api/apis.py
@@ -374,9 +374,7 @@ class Signature(BaseModel):
     var_kw: typing.Optional[typing.Tuple[str, Type]] = None
 
     metadata: typing.Dict[str, int] = pydantic.Field(default_factory=dict)
-    return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = pydantic.Field(
-        default_factory=dict
-    )
+    return_type: OutputType = pydantic.Field()
 
     @pydantic.validator("pos_only_required")
     @classmethod
@@ -415,8 +413,7 @@ class Signature(BaseModel):
     def return_type_annotation(self) -> typing.Optional[cst.Annotation]:
         return_type_annotation = None
         if self.return_type:
-            return_type = create_type(self.return_type)
-            return_type_annotation = cst.Annotation(return_type.annotation)
+            return_type_annotation = cst.Annotation(self.return_type.annotation)
         return return_type_annotation
 
     def function_def(
@@ -530,7 +527,7 @@ class Signature(BaseModel):
         return cls(
             pos_only_required={f"_{i}": create_type(v) for i, v in enumerate(args)},
             kw_only_required={k: create_type(v) for k, v in kwargs.items()},
-            return_type=return_type
+            return_type=create_type(return_type) if return_type else None
         )
 
     @classmethod
@@ -555,7 +552,7 @@ class Signature(BaseModel):
                 if var_kw
                 else None
             ),
-            return_type=return_type
+            return_type=create_type(return_type) if return_type else None
         )
 
     def content_equal(self, other: Signature) -> bool:

--- a/record_api/core.py
+++ b/record_api/core.py
@@ -418,6 +418,10 @@ class Stack:
 
     def log_called_method(self):
         if self.previous_stack.log_call_args:
+            tos = self.TOS
+            if type(tos) is type and issubclass(tos, Exception):
+                # Don't record exception
+                return
             filename, line, fn, args, *kwargs = self.previous_stack.log_call_args
             kwargs = kwargs[0] if kwargs else {}
             log_call(
@@ -425,7 +429,7 @@ class Stack:
                 fn,
                 tuple(args),
                 *((kwargs,) if kwargs else ()),
-                return_type=type(self.TOS),
+                return_type=type(tos),
             )
 
     # special case subscr b/c we only check first arg, not both

--- a/record_api/core.py
+++ b/record_api/core.py
@@ -305,6 +305,9 @@ class Stack:
         self.op_stack = get_stack.OpStack(self.frame)
         self.opcode = self.frame.f_code.co_code[self.frame.f_lasti]
 
+        if self.previous_stack and self.previous_stack.previous_stack:
+            del self.previous_stack.previous_stack
+
     @property
     def oparg(self):
         # sort of replicates logic in dis._unpack_opargs but doesn't account for extended

--- a/record_api/core.py
+++ b/record_api/core.py
@@ -632,7 +632,7 @@ class Tracer:
                 previous_stack=self.previous_stack,
             )
             stack()
-            self.previous_stack = stack
+            self.previous_stack = stack if stack.log_call_args else None
         return None
 
     def should_trace_frame(self, frame) -> bool:

--- a/record_api/infer_apis.py
+++ b/record_api/infer_apis.py
@@ -42,7 +42,11 @@ def __main__():
 
 
 def parse_line(
-    n: int, function: object, params=None, bound_params=None, return_type=None
+    n: int,
+    function: object,
+    params=None,
+    bound_params=None,
+    return_type: typing.Optional[typing.Dict[str, typing.Union[str, typing.Dict]]] = None
 ) -> typing.Optional[API]:
     if bound_params is not None:
         signature = Signature.from_bound_params(**bound_params, return_type=return_type)

--- a/record_api/infer_apis.py
+++ b/record_api/infer_apis.py
@@ -42,7 +42,7 @@ def __main__():
 
 
 def parse_line(
-    n: int, function: object, params=None, bound_params=None,
+    n: int, function: object, params=None, bound_params=None, return_type=None
 ) -> typing.Optional[API]:
     if bound_params is not None:
         signature = Signature.from_bound_params(**bound_params)

--- a/record_api/infer_apis.py
+++ b/record_api/infer_apis.py
@@ -45,9 +45,9 @@ def parse_line(
     n: int, function: object, params=None, bound_params=None, return_type=None
 ) -> typing.Optional[API]:
     if bound_params is not None:
-        signature = Signature.from_bound_params(**bound_params)
+        signature = Signature.from_bound_params(**bound_params, return_type=return_type)
     else:
-        signature = Signature.from_params(**params)
+        signature = Signature.from_params(**params, return_type=return_type)
     signature.metadata[f"usage.{LABEL}"] = n
     return process_function(create_type(function), s=signature)
 

--- a/record_api/test.py
+++ b/record_api/test.py
@@ -1,6 +1,5 @@
 import operator as op
 import unittest
-import typing
 from unittest.mock import call, patch, ANY
 
 import numpy as np
@@ -121,19 +120,19 @@ class TestMockNumPyMethod(BaseTest):
     def test_arange(self):
         self.trace("np.arange(10)")
         self.mock.assert_called_once_with(
-            ANY, np.arange, (10,),
+            ANY, np.arange, (10,), return_type=np.ndarray
         )
 
     def test_arange_in_fn(self):
         self.trace("(lambda: np.arange(10))()")
         self.mock.assert_called_once_with(
-            ANY, np.arange, (10,),
+            ANY, np.arange, (10,), return_type=np.ndarray
         )
 
     def test_power(self):
         self.trace("np.power(100, 10)")
         self.mock.assert_called_once_with(
-            ANY, np.power, (100, 10),
+            ANY, np.power, (100, 10), return_type=np.int64
         )
 
     def test_sort(self):
@@ -158,7 +157,7 @@ class TestMockNumPyMethod(BaseTest):
 
     def test_reshape(self):
         self.trace("self.a.reshape((5, 2))")
-        self.assertCalls(call(ANY, np.ndarray.reshape, (self.a, (5, 2),),))
+        self.assertCalls(call(ANY, np.ndarray.reshape, (self.a, (5, 2),), return_type=np.ndarray))
 
     def test_transpose(self):
         self.trace("self.a.T")
@@ -176,18 +175,18 @@ class TestMockNumPyMethod(BaseTest):
         from numeric function to test array dispatch
         """
         self.trace("np.ravel([1, 2, 3])")
-        self.assertCalls(call(ANY, np.ravel, ([1, 2, 3],)))
+        self.assertCalls(call(ANY, np.ravel, ([1, 2, 3],), return_type=np.ndarray))
 
     def test_ravel_array(self):
         """
         from numeric function to test array dispatch
         """
         self.trace("np.ravel(self.a,)")
-        self.assertCalls(call(ANY, np.ravel, (self.a,)))
+        self.assertCalls(call(ANY, np.ravel, (self.a,), return_type=np.ndarray),)
 
     def test_std(self):
         self.trace("np.std(self.a,)")
-        self.assertCalls(call(ANY, np.std, (self.a,)))
+        self.assertCalls(call(ANY, np.std, (self.a,), return_type=np.float64))
 
     def test_builtin_types_no_call(self):
         self.trace("10 + 10\n12323.234 - 2342.40")
@@ -208,17 +207,18 @@ class TestMockNumPyMethod(BaseTest):
         self.trace("np.add.reduce(self.a,)")
         self.assertCalls(
             call(ANY, getattr, (np, "add")),
-            call(ANY, np.ufunc.reduce, (np.add, self.a)),
+            call(ANY, np.ufunc.reduce, (np.add, self.a), return_type=np.int64),
         )
 
     def test_method(self):
         self.trace("self.a.sum()")
-        self.assertCalls(call(ANY, np.ndarray.sum, (self.a,)))
+        self.assertCalls(call(ANY, np.ndarray.sum, (self.a,), return_type=np.int64))
 
     def test_method_unbound(self):
         self.trace("np.ndarray.sum(self.a,)")
         self.assertCalls(
-            call(ANY, getattr, (np, "ndarray")), call(ANY, np.ndarray.sum, (self.a,))
+            call(ANY, getattr, (np, "ndarray")),
+            call(ANY, np.ndarray.sum, (self.a,), return_type=np.int64)
         )
 
     def test_contains(self):
@@ -239,7 +239,7 @@ class TestMockPandasMethod(BaseTest):
         self.trace("pd.DataFrame.from_records([{'hi': 1}])")
         self.assertCalls(
             call(ANY, getattr, (pd, "DataFrame")),
-            call(ANY, pd.DataFrame.from_records, ([{"hi": 1}],)),
+            call(ANY, pd.DataFrame.from_records, ([{"hi": 1}],), return_type=pd.DataFrame),
         )
 
 

--- a/record_api/test.py
+++ b/record_api/test.py
@@ -139,20 +139,20 @@ class TestMockNumPyMethod(BaseTest):
         self.trace("self.a.sort(axis=0)")
         self.assertCalls(
             call(ANY, getattr, (self.a, "sort")),
-            call(ANY, self.a.sort, (), {"axis": 0}),
+            call(ANY, self.a.sort, (), {"axis": 0}, return_type=type(None)),
         )
 
     def test_eye(self):
         self.trace("np.eye(10, order='F')")
         self.assertCalls(
-            call(ANY, getattr, (np, "eye")), call(ANY, np.eye, (10,), {"order": "F"}),
+            call(ANY, getattr, (np, "eye")), call(ANY, np.eye, (10,), {"order": "F"}, return_type=np.ndarray),
         )
 
     def test_linspace(self):
         self.trace("np.linspace(3, 4, endpoint=False)")
         self.assertCalls(
             call(ANY, getattr, (np, "linspace",)),
-            call(ANY, np.linspace, (3, 4,), {"endpoint": False}),
+            call(ANY, np.linspace, (3, 4,), {"endpoint": False}, return_type=np.ndarray),
         )
 
     def test_reshape(self):
@@ -167,7 +167,7 @@ class TestMockNumPyMethod(BaseTest):
         self.trace("np.concatenate((self.a, self.a), axis=0)")
         self.assertCalls(
             call(ANY, getattr, (np, "concatenate",)),
-            call(ANY, np.concatenate, ((self.a, self.a),), {"axis": 0}),
+            call(ANY, np.concatenate, ((self.a, self.a),), {"axis": 0}, return_type=np.ndarray),
         )
 
     def test_ravel_list(self):
@@ -196,7 +196,7 @@ class TestMockNumPyMethod(BaseTest):
         self.trace("np.ndarray(dtype='int64', shape=tuple())")
         self.assertCalls(
             call(ANY, getattr, (np, "ndarray")),
-            call(ANY, np.ndarray, (), {"dtype": "int64", "shape": tuple()}),
+            call(ANY, np.ndarray, (), {"dtype": "int64", "shape": tuple()}, return_type=np.ndarray),
         )
 
     def test_not_contains(self):

--- a/record_api/type_analysis.py
+++ b/record_api/type_analysis.py
@@ -532,11 +532,11 @@ class TypeOutput(OutputTypeBase):
         )
 
     @classmethod
-    def unify(cls, tps: typing.Iterable[TypeOutput]) -> TypeOutput:
+    def unify(cls, tps: typing.Iterable[TypeOutput]) -> typing.Union[TypeOutput, UnionOutput]:
         names = set(tp.name for tp in tps)
         if len(names) == 1:
             return TypeOutput(name=names.pop())
-        return TypeOutput()
+        return UnionOutput(options=tuple(tps))
 
     @property
     def module(self) -> typing.Optional[str]:


### PR DESCRIPTION
This is an attempt to implement #15 to record function return types.

It delays the call to `log_call` method and saves the arguments as an attribute (`log_call_args`) of the Stack class. The Stack now has a `previous_stack` attribute to check it the previous stack opname was `CALL_METHOD`, so that delayed call to `log_call` can be executed with the known returned value.

TODO:

- [x] Tracing for all op codes except:
`STORE_ATTR`: doesn’t returns anything as it sets a value
`DELETE_SUBSCR`: doesn’t returns anything
`STORE_SUBSCR`: doesn’t returns anything
`BUILD_TUPLE_UNPACK`: will return tuple
`BUILD_LIST_UNPACK`: will always return list
`BUILD_SET_UNPACK`: will always return set
`BUILD_TUPLE_UNPACK_WITH_CALL`: will always return tuple
`COMPARE_OP`: will always return boolean
- [x] Do not trace exception return types
- [x] Union of return types if a function returns more than one type (for e.g: `np.add(1, 1)` and `np.add(1, 1.2)`)
- [x] Return type hint in the final output