### PR TITLE
Dicts with unknown keys should be top type not bottom type

### DIFF
--- a/record_api/type_analysis.py
+++ b/record_api/type_analysis.py
@@ -311,8 +311,8 @@ class DictInput(InputTypeBase):
         if self.v:
             key, value = map(unify_inputs, zip(*self.v))
         else:
-            key = BottomOutput()
-            value = BottomOutput()
+            key = ObjectOutput()
+            value = ObjectOutput()
         return DictOutput(key=key, value=value)
 
 


### PR DESCRIPTION
When they unify with other types should stay as object/any/top not result in other type.