### PR TITLE
Fix cloning buildx in github actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build, test and push Docker images
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout repo
         uses: actions/checkout@master
 
       - name: Set up Python
@@ -61,12 +61,12 @@ jobs:
         if: steps.cache-buildx.outputs.cache-hit != 'true'
         with:
           repository: docker/buildx
-          path: /tmp/buildx-source
+          path: ./buildx-source
           ref: fd6de6b6aeac780c59e5079a96b068076b676d73
 
       - name: Install buildx
         if: steps.cache-buildx.outputs.cache-hit != 'true'
-        working-directory: /tmp/buildx-source
+        working-directory: ./buildx-source
         run: make install
 
       - name: Install doctl

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/raw/*
 dist/
 data/groupby_location/
 **/.DS_Store
+buildx-source


### PR DESCRIPTION
Looks like github stopped allowing us to clone into non relative directories. This fixes it by cloning it in the current directory. Fixes https://github.com/data-apis/python-record-api/issues/83