### PR TITLE
Switch digitial ocean to github docker registry

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -74,8 +74,8 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
-      - name: Login DigitalOcean container registry
-        run: doctl registry login
+      - name: Login to Github Container Registry
+        run: docker login ghcr.io -u saulshanabrook -p "${{ secrets.CR_PAT }}"
 
       - name: Save DigitalOcean kubeconfig
         run: doctl kubernetes cluster kubeconfig save python-record-api

--- a/k8/Makefile
+++ b/k8/Makefile
@@ -4,7 +4,7 @@ PYTHON_PACKAGE_VERSION := $(shell python -c 'import record_api; print(record_api
 
 $(info Python package version = ${PYTHON_PACKAGE_VERSION})
 
-IMAGE := registry.digitalocean.com/python-record-api
+IMAGE := ghcr.io/data-apis
 
 # The tag for base image is base-{python version}-{version-increment}
 # The tag for other versions are {name}-{python version}-{base version increment}-{version increment}

--- a/k8/Makefile
+++ b/k8/Makefile
@@ -15,13 +15,10 @@ version = $(shell cat images/$(1)/version)
 
 BASE_IMAGE := ${IMAGE}/base:${PYTHON_PACKAGE_VERSION}-$(call version,base)
 
-BASE_CACHE_IMAGE := ${IMAGE}/base:cache
-
 $(info Base image = ${BASE_IMAGE})
 
 sub_tag = $(1):${PYTHON_PACKAGE_VERSION}-$(call version,base)-$(call version,$(1))
 sub_image = ${IMAGE}/$(call sub_tag,$(1))
-sub_cache_image = ${IMAGE}/$(1):cache
 
 WORKFLOW_VERSION := $(shell cat argo/version)
 $(info Workflow version = ${WORKFLOW_VERSION})
@@ -151,8 +148,6 @@ define JQ_DOCKER_BAKE
 			base: {
 				context: "images/base",
 				inherits: ["base-base"],
-				"cache-to": ["type=registry,ref=${BASE_CACHE_IMAGE},mode=max"],
-				"cache-from": ["type=registry,ref=${BASE_CACHE_IMAGE}"],
 				args: {
 					PYTHON_PACKAGE_VERSION: "${PYTHON_PACKAGE_VERSION}"
 				},
@@ -171,8 +166,6 @@ define JQ_DOCKER_BAKE
 						args: {
 							FROM: "${BASE_IMAGE}"
 						},
-						"cache-to": ["type=registry,ref=" + ($$ARGS.named[(. + "-cache")]) + ",mode=max"],
-						"cache-from": ["type=registry,ref=" + ($$ARGS.named[(. + "-cache")])],
 						tags: [
 							($$ARGS.named[(.)])
 						]
@@ -191,7 +184,6 @@ docker-bake.json: Makefile images/
 	jq "$$JQ_DOCKER_BAKE" \
 		--null-input \
 		$(foreach name,$(IMAGES),--arg $(name) $(call sub_image,$(name))) \
-		$(foreach name,$(IMAGES),--arg $(name)-cache $(call sub_cache_image,$(name))) \
 		--args $(IMAGES) \
 		> $@
 

--- a/k8/Makefile
+++ b/k8/Makefile
@@ -144,6 +144,9 @@ define JQ_DOCKER_BAKE
 		{
 			"base-base": {
 				dockerfile: "Dockerfile",
+				labels: {
+					"org.opencontainers.image.source": "https://github.com/data-apis/python-record-api"
+				}
 			},
 			base: {
 				context: "images/base",


### PR DESCRIPTION
Fixes https://github.com/data-apis/python-record-api/issues/91 by switching to the [Github Container Registry](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry/about-github-container-registry) from the digitial ocean registry, which can have public images.