### PR TITLE
Build base image locally for testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!record_api
+!pyproject.toml

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Then you can test an image locally, to make sure the Dockerfile builds correctly
 ```bash
 cd k8
 make test-local-<LIBRARY NAME>
+
+# to test against the local python package, instead of the released one
+make PYTHON_PACKAGE=. test-local-<LIBRARY NAME>
 ```
 
 This should output a number of lines of traces.

--- a/k8/Makefile
+++ b/k8/Makefile
@@ -1,8 +1,9 @@
 
 TO_MODULES := pandas,numpy
 PYTHON_PACKAGE_VERSION := $(shell python -c 'import record_api; print(record_api.__version__)')
+PYTHON_PACKAGE ?= record_api==${PYTHON_PACKAGE_VERSION}
 
-$(info Python package version = ${PYTHON_PACKAGE_VERSION})
+$(info Python package = ${PYTHON_PACKAGE})
 
 IMAGE := registry.digitalocean.com/python-record-api
 
@@ -97,6 +98,12 @@ push-images: docker-bake.json
 
 test-local-%:
 	env DOCKER_BUILDKIT=1 docker build \
+		--tag ${BASE_IMAGE} \
+		--file images/base/Dockerfile \
+		--build-arg "PYTHON_PACKAGE=${PYTHON_PACKAGE}" \
+		..
+	
+	env DOCKER_BUILDKIT=1 docker build \
 		--tag $(call sub_image,$(*F)) \
 		--build-arg "FROM=${BASE_IMAGE}" \
 		images/$(*F)
@@ -119,13 +126,6 @@ test-remote-%: docker-bake.json
 		--image=$(call sub_image,$(*F))
 
 
-# push-images:  $(addprefix push-image-,$(IMAGES))
-
-# push-image-%:
-# 	docker push saulshanabrook/python-record-api:$(*F)-$(TAG)
-
-# build-images: docker-bake.json
-# 	docker buildx bake
 
 
 # Generate docker bake file with default group
@@ -151,7 +151,7 @@ define JQ_DOCKER_BAKE
 				"cache-to": ["type=registry,ref=${BASE_CACHE_IMAGE},mode=max"],
 				"cache-from": ["type=registry,ref=${BASE_CACHE_IMAGE}"],
 				args: {
-					PYTHON_PACKAGE_VERSION: "${PYTHON_PACKAGE_VERSION}"
+					PYTHON_PACKAGE: "${PYTHON_PACKAGE}"
 				},
 				tags: [
 					"${BASE_IMAGE}"


### PR DESCRIPTION
Fixes https://github.com/data-apis/python-record-api/issues/91 by building base image locally, so we don't need to pull it.